### PR TITLE
fix: avoid synthesizing invalid function names in named evaluation

### DIFF
--- a/src/instrument/fix-named-eval.ts
+++ b/src/instrument/fix-named-eval.ts
@@ -29,8 +29,45 @@ function hasSelfBinding(func: acorn.FunctionExpression | acorn.ArrowFunctionExpr
 // A simple ASCII identifier check.  Names from non-identifier string literals (e.g.
 // "foo bar") cannot be used as function names in generated source.
 const IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+const RESERVED_WORDS = new Set([
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);
 function isIdentifier(name: string): boolean {
-  return IDENTIFIER_RE.test(name);
+  return IDENTIFIER_RE.test(name) && !RESERVED_WORDS.has(name);
 }
 
 // Pre-pass: mutate all anonymous functions that sit in NamedEvaluation positions
@@ -77,7 +114,8 @@ export function fixNamedEvaluations(ast: acorn.Node): void {
         ) {
           // The property name is NOT a variable binding, so only FunctionExpression is safe.
           if (!hasSelfBinding(func)) return;
-          applyNamedEvaluation(func, ((left as acorn.MemberExpression).property as acorn.Identifier).name);
+          const name = ((left as acorn.MemberExpression).property as acorn.Identifier).name;
+          if (isIdentifier(name)) applyNamedEvaluation(func, name);
         }
       }
     },

--- a/tests/regression-trace/trace-all/named-eval-11.js
+++ b/tests/regression-trace/trace-all/named-eval-11.js
@@ -1,0 +1,5 @@
+// reserved-word string literal key — named eval must NOT apply (name stays null)
+var obj = {
+    "return": function () {},
+};
+obj["return"]();

--- a/tests/regression-trace/trace-all/named-eval-11.out
+++ b/tests/regression-trace/trace-all/named-eval-11.out
@@ -1,0 +1,17 @@
+Se() @ 1:1-6:1
+  D(obj, <var>, undefined, false) @ 1:1-6:1
+  L(<function>) @ 3:15-29
+  L(<object>) @ 2:11-4:2
+  E(<object>) @ 2:11-4:2
+  W([obj], <object>) @ 2:11-4:2
+  R(obj, <object>) @ 5:1-4
+  L("return") @ 5:5-13
+  G[pre](<object>, "return") @ 5:1-14
+  G(<object>, "return", <function>) @ 5:1-14
+  F[pre](<function>, <object>, [], false, true) @ 5:1-14
+  Fe(null, <object>, []) @ 3:15-29
+    D(arguments, <arguments>, <object>, false) @ 3:15-29
+  Fx(undefined) @ 3:15-29
+  F(<function>, <object>, [], undefined, false, true) @ 5:1-14
+  E(undefined) @ 5:1-16
+Sx() @ 1:1-6:1


### PR DESCRIPTION
DynaJS's named-evaluation pass could synthesize a function name from a property key even when that key is not valid in function-identifier position.

  For example, this valid input:

  ```js
  var obj = {
    "return": function () {},
  };
```
  could be instrumented into invalid JavaScript:
```js
  var obj = {
    "return": function return() {},
  };
```
  which fails at parse time with: ```SyntaxError: Unexpected token 'return'```

The fix only applies inferred names when they are valid non-reserved identifiers, and otherwise leaves the function anonymous.

Also added a regression test for the reserved-word case in `named-eval-11.js`. The test fails without the fix by producing invalid instrumented JS, and passes with the fix.