### PR TITLE
Prevent named evalutation when body references the variable name

### DIFF
--- a/src/instrument/fix-named-eval.ts
+++ b/src/instrument/fix-named-eval.ts
@@ -26,6 +26,18 @@ function hasSelfBinding(func: acorn.FunctionExpression | acorn.ArrowFunctionExpr
   return func.type === 'FunctionExpression';
 }
 
+function referencesName(node: acorn.Node, name: string): boolean {
+  let found = false;
+  simple(node, {
+    Identifier(identifier) {
+      if ((identifier as acorn.Identifier).name === name) {
+        found = true;
+      }
+    },
+  });
+  return found;
+}
+
 // temporal fix
 const TOP_PRIORITY_TARGETS = new Set([
   'toString', 'valueOf'
@@ -87,6 +99,7 @@ export function fixNamedEvaluations(ast: acorn.Node): void {
     VariableDeclarator(node) {
       const { id, init } = node as acorn.VariableDeclarator;
       if (init != null && id.type === 'Identifier' && isFuncExpr(init)) {
+        if (hasSelfBinding(init) && referencesName(init.body as acorn.Node, id.name)) return;
         applyNamedEvaluation(init, id.name);
       }
     },


### PR DESCRIPTION
Applying named evaluation on the variable declarator case when the body has a self-reference inside will cause an infinite loop. This PR prevents that by skipping these cases.